### PR TITLE
Support fractional seconds

### DIFF
--- a/src/duration/duration.spec.ts
+++ b/src/duration/duration.spec.ts
@@ -48,6 +48,9 @@ describe('Duration', () => {
       expect(() => Duration.fromJS('P0Y0MT0H0M0S').shift(new Date(), TZ_LA)).toThrow(
         'Duration can not be empty',
       );
+
+      expect(() => Duration.fromJS('PT0.0.1S')).toThrow("Can not parse duration 'PT0.0.1S'");
+      expect(() => Duration.fromJS('PT0..1S')).toThrow("Can not parse duration 'PT0..1S'");
     });
 
     it('throws error if fromJS is not given a string', () => {
@@ -70,10 +73,14 @@ describe('Duration', () => {
 
       durationStr = 'P3DT15H';
       expect(Duration.fromJS(durationStr).toString()).toEqual(durationStr);
+
+      durationStr = 'PT0.001S';
+      expect(Duration.fromJS(durationStr).toString()).toEqual(durationStr);
     });
 
     it('eliminates 0', () => {
       expect(Duration.fromJS('P0DT15H').toString()).toEqual('PT15H');
+      expect(Duration.fromJS('PT00000.00001S').toString()).toEqual('PT0.00001S');
     });
   });
 
@@ -420,6 +427,18 @@ describe('Duration', () => {
 
       durationStr = 'P3DT15H';
       expect(Duration.fromJS(durationStr).getCanonicalLength()).toEqual(313200000);
+
+      durationStr = 'PT0.1S';
+      expect(Duration.fromJS(durationStr).getCanonicalLength()).toEqual(100);
+
+      durationStr = 'PT0.01S';
+      expect(Duration.fromJS(durationStr).getCanonicalLength()).toEqual(10);
+
+      durationStr = 'PT0.001S';
+      expect(Duration.fromJS(durationStr).getCanonicalLength()).toEqual(1);
+
+      durationStr = 'PT0.0001S';
+      expect(Duration.fromJS(durationStr).getCanonicalLength()).toEqual(0.1);
     });
   });
 
@@ -527,6 +546,12 @@ describe('Duration', () => {
 
       durationStr = 'P3DT15H';
       expect(Duration.fromJS(durationStr).getDescription(true)).toEqual('3 Days, 15 Hours');
+
+      durationStr = 'PT1S';
+      expect(Duration.fromJS(durationStr).getDescription()).toEqual('second');
+
+      durationStr = 'PT0.001S';
+      expect(Duration.fromJS(durationStr).getDescription()).toEqual('0.001 seconds');
     });
   });
 
@@ -545,6 +570,9 @@ describe('Duration', () => {
 
       durationStr = 'PT5H';
       expect(Duration.fromJS(durationStr).getSingleSpan()).toEqual('hour');
+
+      durationStr = 'PT0.001S';
+      expect(Duration.fromJS(durationStr).getSingleSpan()).toEqual('second');
 
       durationStr = 'P3DT15H';
       expect(Duration.fromJS(durationStr).getSingleSpan()).toBeUndefined();
@@ -569,6 +597,9 @@ describe('Duration', () => {
 
       durationStr = 'PT5H';
       expect(Duration.fromJS(durationStr).getSingleSpanValue()).toEqual(5);
+
+      durationStr = 'PT0.001S';
+      expect(Duration.fromJS(durationStr).getSingleSpanValue()).toEqual(0.001);
 
       durationStr = 'P3DT15H';
       expect(Duration.fromJS(durationStr).getSingleSpanValue()).toBeUndefined();

--- a/src/duration/duration.ts
+++ b/src/duration/duration.ts
@@ -44,8 +44,10 @@ function capitalizeFirst(str: string): string {
 }
 
 const periodWeekRegExp = /^P(\d+)W$/;
-const periodRegExp = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
-//                   P   (year ) (month   ) (day     )    T(hour    ) (minute  ) (second  )
+const periodRegExp =
+  /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:((\d+\.)?\d+)S)?)?$/;
+//  P   (year ) (month   ) (day     )    T(hour    ) (minute  ) (second            )
+
 function getSpansFromString(durationStr: string): DurationValue {
   const spans: DurationValue = {};
   let matches: RegExpExecArray | null;


### PR DESCRIPTION
[ISO8601 and Temporal support fractional seconds in durations](https://tc39.es/proposal-temporal/docs/duration.html), so we should too.

This PR only implements basic parsing support. Fractional values are still reported as units of "second" in description strings. A future PR will improve this.