### PR TITLE
Make more durations floorable and fix materialize

### DIFF
--- a/.changeset/modern-games-sneeze.md
+++ b/.changeset/modern-games-sneeze.md
@@ -1,0 +1,5 @@
+---
+'chronoshift': minor
+---
+
+Make more durations floorable and fix materialize

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,5 +1,5 @@
 <component name="InspectionProjectProfileManager">
-  <profile version="1.0" is_locked="false">
+  <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FunctionNamingConventionJS" enabled="true" level="WARNING" enabled_by_default="true">

--- a/src/duration/duration.spec.ts
+++ b/src/duration/duration.spec.ts
@@ -198,18 +198,26 @@ describe('Duration', () => {
     });
   });
 
-  describe('#isFloorable', () => {
+  describe('#isFloorable / #makeFloorable', () => {
     it('works on floorable things', () => {
-      const vs = 'P1Y P5Y P10Y P100Y P1M P2M P3M P4M P1D'.split(' ');
+      const vs = 'P1Y P5Y P10Y P100Y P1M P2M P3M P4M P1D P2D P3D P5D'.split(' ');
       for (const v of vs) {
         expect(Duration.fromJS(v).isFloorable(), v).toEqual(true);
+        expect(Duration.fromJS(v).makeFloorable().toString(), v).toEqual(v);
       }
     });
 
     it('works on not floorable things', () => {
-      const vs = 'P1Y1M P5M P2D P3D'.split(' ');
+      const vs = [
+        { unfloorable: 'P1Y1M', floorable: 'P1Y' },
+        { unfloorable: 'P5M', floorable: 'P1M' },
+        { unfloorable: 'P4D', floorable: 'P1D' },
+      ];
       for (const v of vs) {
-        expect(Duration.fromJS(v).isFloorable(), v).toEqual(false);
+        expect(Duration.fromJS(v.unfloorable).isFloorable(), v.unfloorable).toEqual(false);
+        expect(Duration.fromJS(v.floorable).makeFloorable().toString(), v.unfloorable).toEqual(
+          v.floorable,
+        );
       }
     });
   });
@@ -458,6 +466,22 @@ describe('Duration', () => {
   });
 
   describe('#materialize', () => {
+    it('works for hours', () => {
+      const pt1h = new Duration('PT1H');
+
+      expect(
+        pt1h.materialize(
+          new Date('2012-10-29T00:05:00-07:00'),
+          new Date('2012-10-29T03:05:00-07:00'),
+          TZ_LA,
+        ),
+      ).toEqual([
+        new Date('2012-10-29T01:00:00-07:00'),
+        new Date('2012-10-29T02:00:00-07:00'),
+        new Date('2012-10-29T03:00:00-07:00'),
+      ]);
+    });
+
     it('works for weeks', () => {
       const p1w = new Duration('P1W');
 

--- a/src/duration/duration.ts
+++ b/src/duration/duration.ts
@@ -274,6 +274,16 @@ export class Duration implements ImmutableClassInstance<DurationValue, string> {
     return siblings % span === 0;
   }
 
+  public makeFloorable(): Duration {
+    if (this.isFloorable()) return this;
+    const { singleSpan, spans } = this;
+    if (singleSpan) return new Duration({ [singleSpan]: 1 });
+    for (const span of SPANS_WITH_WEEK) {
+      if (spans[span]) return new Duration({ [span]: 1 });
+    }
+    return new Duration({ second: 1 });
+  }
+
   /**
    * Floors the date according to this duration.
    * @param date The date to floor
@@ -358,7 +368,7 @@ export class Duration implements ImmutableClassInstance<DurationValue, string> {
    */
   public materialize(start: Date, end: Date, timezone: Timezone, step = 1): Date[] {
     const values: Date[] = [];
-    let iter = this.floor(start, timezone);
+    let iter = this.makeFloorable().ceil(start, timezone);
     while (iter <= end) {
       values.push(iter);
       iter = this.shift(iter, timezone, step);

--- a/src/floor-shift-ceil/floor-shift-ceil.ts
+++ b/src/floor-shift-ceil/floor-shift-ceil.ts
@@ -27,7 +27,7 @@ export type RoundFn = (dt: Date, roundTo: number, tz: Timezone) => Date;
 
 export interface TimeShifterNoCeil {
   canonicalLength: number;
-  siblings?: number;
+  siblings: number;
   floor: AlignFn;
   round: RoundFn;
   shift: ShiftFn;
@@ -137,6 +137,7 @@ export const hour = timeShifterFiller({
 
 export const day = timeShifterFiller({
   canonicalLength: 24 * 3600000,
+  siblings: 30,
   floor: (dt, tz) => {
     if (tz.isUTC()) {
       dt = new Date(dt.valueOf());
@@ -164,6 +165,7 @@ export const day = timeShifterFiller({
 
 export const week = timeShifterFiller({
   canonicalLength: 7 * 24 * 3600000,
+  siblings: 52,
   floor: (dt, tz) => {
     if (tz.isUTC()) {
       dt = new Date(dt.valueOf());
@@ -272,9 +274,13 @@ export const year = timeShifterFiller({
   shift: yearShift,
 });
 
+/**
+ * @deprecated use `new Duration('P${numDays}D')` instead
+ */
 export function getMultiDayShifter(numDays: number) {
   return timeShifterFiller({
     canonicalLength: 24 * 3600000 * numDays,
+    siblings: 1, // This is a no-op dummy
     floor: day.floor,
     shift: (dt, tz, step) => day.shift(dt, tz, step * numDays),
     round: () => {


### PR DESCRIPTION
This PR makes durations like `P2D` floorable by "assuming" that a month has 30 days. So that P2D would still floor the start of the month correctly.

Also fixes `materialize` to ceil the starting bound instead of flooring it which is wrong and expands the places where it can be used.