### PR TITLE
Add npm trusted publishing support

### DIFF
--- a/.changeset/npm-trusted-publishing.md
+++ b/.changeset/npm-trusted-publishing.md
@@ -1,0 +1,5 @@
+---
+"chronoshift": patch
+---
+
+Add npm trusted publishing support for automated releases via OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npx changeset publish --provenance
+          publish: npx changeset publish
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
     if: github.repository == 'implydata/chronoshift'
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -31,11 +35,14 @@ jobs:
 
       - run: npm install --prefer-offline --no-audit
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npx changeset publish --otp=1
+          publish: npx changeset publish --provenance
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds support for npm trusted publishing via OIDC, which allows automated publishing without requiring OTP tokens.

## Changes

- Added `id-token: write`, `contents: write`, and `pull-requests: write` permissions to the release job
- Added npm update step to ensure latest npm version for provenance support
- Replaced `--otp=1` with `--provenance` flag in the npm publish command
- Added changeset for this change
- This enables automated publishing via OIDC authentication

## Benefits

- No more manual OTP entry required for publishing
- Enhanced security through OIDC-based authentication
- Automatic provenance generation for published packages

## References

- [npm Trusted Publishers Documentation](https://docs.npmjs.com/trusted-publishers)
- [npm Provenance Documentation](https://docs.npmjs.com/generating-provenance-statements)

## Next Steps

After merging this PR, you'll need to configure the trusted publisher on npm:
1. Go to https://www.npmjs.com/package/chronoshift/access
2. Set up GitHub Actions as a trusted publisher
3. Configure the repository, workflow file, and job name