### PR TITLE
Fix minute.round with non-integer TZ offsets

### DIFF
--- a/.changeset/ninety-cycles-hug.md
+++ b/.changeset/ninety-cycles-hug.md
@@ -1,0 +1,5 @@
+---
+'chronoshift': patch
+---
+
+Fix minute.round with non-integer TZ offsets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chronoshift",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chronoshift",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@internationalized/date": "^3.5.6",

--- a/src/duration/duration.spec.ts
+++ b/src/duration/duration.spec.ts
@@ -264,6 +264,31 @@ describe('Duration', () => {
       );
     });
 
+    it('works for PT20M with Asia/Kolkata (UTC+5:30)', () => {
+      const pt20m = new Duration('PT20M');
+      const kolkata = Timezone.fromJS('Asia/Kolkata');
+
+      // 12:00 UTC = 17:30 IST → floor to 17:20 IST = 11:50 UTC
+      expect(pt20m.floor(new Date('2025-11-27T12:00:00Z'), kolkata)).toEqual(
+        new Date('2025-11-27T11:50:00.000Z'),
+      );
+
+      // 12:25 UTC = 17:55 IST → floor to 17:40 IST = 12:10 UTC
+      expect(pt20m.floor(new Date('2025-11-27T12:25:00Z'), kolkata)).toEqual(
+        new Date('2025-11-27T12:10:00.000Z'),
+      );
+    });
+
+    it('works for PT5M with Asia/Kolkata (UTC+5:30)', () => {
+      const pt5m = new Duration('PT5M');
+      const kolkata = Timezone.fromJS('Asia/Kolkata');
+
+      // 12:02 UTC = 17:32 IST → floor to 17:30 IST = 12:00 UTC
+      expect(pt5m.floor(new Date('2025-11-27T12:02:00Z'), kolkata)).toEqual(
+        new Date('2025-11-27T12:00:00.000Z'),
+      );
+    });
+
     it('works for P2H', () => {
       const pt2h = new Duration('PT2H');
       expect(pt2h.floor(new Date('2013-09-29T03:02:03.456-07:00'), TZ_LA)).toEqual(

--- a/src/floor-shift-ceil/floor-shift-ceil.spec.ts
+++ b/src/floor-shift-ceil/floor-shift-ceil.spec.ts
@@ -204,4 +204,27 @@ describe('floor/shift/ceil', () => {
       year.shift(new Date('2010-01-01T00:00:00-08:00'), tz, 1),
     );
   });
+
+  it('rounds minutes with non-integer timezone offsets', () => {
+    const kolkata = Timezone.fromJS('Asia/Kolkata');
+    const kathmandu = Timezone.fromJS('Asia/Kathmandu');
+
+    // Asia/Kolkata (UTC+5:30) with 20 minute boundary
+    expect(shifters.minute.round(new Date('2025-11-27T12:00:00Z'), 20, kolkata)).toEqual(
+      new Date('2025-11-27T11:50:00.000Z'),
+    );
+    expect(shifters.minute.round(new Date('2025-11-27T12:25:00Z'), 20, kolkata)).toEqual(
+      new Date('2025-11-27T12:10:00.000Z'),
+    );
+
+    // Asia/Kolkata (UTC+5:30) with 5 minute boundary
+    expect(shifters.minute.round(new Date('2025-11-27T12:02:00Z'), 5, kolkata)).toEqual(
+      new Date('2025-11-27T12:00:00.000Z'),
+    );
+
+    // Asia/Kathmandu (UTC+5:45) with 20 minute boundary
+    expect(shifters.minute.round(new Date('2025-11-27T12:00:00Z'), 20, kathmandu)).toEqual(
+      new Date('2025-11-27T11:55:00.000Z'),
+    );
+  });
 });


### PR DESCRIPTION
Fix minute.round to respect timezone parameter for non-UTC timezones and non-integer offsets.

The minute.round function was ignoring the timezone parameter, causing incorrect bucket alignment for durations like PT20M when used with timezones that have non-integer hour offsets (e.g., Asia/Kolkata at UTC+5:30).

For example, with PT20M and Asia/Kolkata:
- Before: 12:00 UTC (17:30 IST) rounded to 12:00 UTC (wrong)
- After: 12:00 UTC (17:30 IST) rounds to 11:50 UTC (17:20 IST, correct)

Changes:
- Updated minute.round to check timezone and use local minutes for non-UTC
- Test coverage for minute shifter and Duration

The fix follows the same pattern used by hour.round, which already correctly handles timezone-aware rounding.